### PR TITLE
refine rate limiting implementation to clarify per-client usage and a…

### DIFF
--- a/helm/myapp-chart/templates/app-frontend/deployment.yml
+++ b/helm/myapp-chart/templates/app-frontend/deployment.yml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: app-frontend
-          image: "{{ .Values.appFrontend.image.repository }}:{{ .Values.appFrontend.image.tag }}"
+          image: "{{ .Values.appFrontend.image.repository }}:v3.1.0"
           ports:
             - containerPort: {{ .Values.appFrontend.port }}
           env:

--- a/helm/myapp-chart/templates/app-frontend/deployment.yml
+++ b/helm/myapp-chart/templates/app-frontend/deployment.yml
@@ -21,7 +21,7 @@ spec:
     spec:
       containers:
         - name: app-frontend
-          image: "{{ .Values.appFrontend.image.repository }}:v3.1.0"
+          image: "{{ .Values.appFrontend.image.repository }}:{{ .Values.appFrontend.versions.v1.tag }}"
           ports:
             - containerPort: {{ .Values.appFrontend.port }}
           env:
@@ -74,7 +74,7 @@ spec:
     spec:
       containers:
         - name: app-frontend
-          image: "{{ .Values.appFrontend.image.repository }}:v3.2.0"
+          image: "{{ .Values.appFrontend.image.repository }}:{{ .Values.appFrontend.versions.v2.tag }}"
           ports:
             - containerPort: {{ .Values.appFrontend.port }}
           env:

--- a/helm/myapp-chart/templates/istio/ratelimit.yml
+++ b/helm/myapp-chart/templates/istio/ratelimit.yml
@@ -1,6 +1,6 @@
 {{- if .Values.rateLimit.enabled }}
 # Rate limiting using Envoy's local rate limiting filter
-# This implements per-user IP rate limiting to prevent abuse while maintaining sticky sessions
+# This implements per-client IP rate limiting to prevent abuse while maintaining sticky sessions
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -30,11 +30,11 @@ spec:
             type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
             value:
               stat_prefix: http_local_rate_limiter
-              # Token bucket: {{ .Values.rateLimit.requestsPerMinute }} requests per minute
+              # Per-client rate limiting: {{ .Values.rateLimit.requestsPerMinute }} requests per minute per source IP
               token_bucket:
                 max_tokens: {{ .Values.rateLimit.requestsPerMinute }}
                 tokens_per_fill: {{ .Values.rateLimit.requestsPerMinute }}
-                fill_interval: 20s
+                fill_interval: 60s  # 1 minute interval for proper per-minute limiting
               # Enable the filter for all requests
               filter_enabled:
                 runtime_key: local_rate_limit_enabled
@@ -47,9 +47,16 @@ spec:
                 default_value:
                   numerator: 100
                   denominator: HUNDRED
+              # Per-client rate limiting based on source IP
+              descriptors:
+              - entries:
+                - key: remote_address
+                rate_limit:
+                  unit: minute
+                  requests_per_unit: {{ .Values.rateLimit.requestsPerMinute }}
               # Return empty response body when rate limited (only 429 status code)
               local_reply_config:
                 status_code: 429
-                # body:
-                #   inline_string: ""
+                body:
+                  inline_string: "Rate limit exceeded. You are making requests too quickly. Please wait before trying again."
 {{- end }}

--- a/helm/myapp-chart/templates/istio/ratelimit.yml
+++ b/helm/myapp-chart/templates/istio/ratelimit.yml
@@ -1,6 +1,7 @@
 {{- if .Values.rateLimit.enabled }}
-# Rate limiting using Envoy's local rate limiting filter
-# This implements per-client IP rate limiting to prevent abuse while maintaining sticky sessions
+# Rate limiting using Envoy's local rate limiting filter with per-user buckets
+# This implements per-user rate limiting using source IP to create separate buckets per user
+# Similar to sticky sessions approach, each user (source IP) gets their own rate limit bucket
 apiVersion: networking.istio.io/v1alpha3
 kind: EnvoyFilter
 metadata:
@@ -11,7 +12,7 @@ spec:
     labels:
       istio: ingressgateway
   configPatches:
-    # Insert the local rate limiting filter in the HTTP filter chain
+    # First, add a filter to inject the source IP as a header for rate limiting
     - applyTo: HTTP_FILTER
       match:
         context: GATEWAY
@@ -24,13 +25,36 @@ spec:
       patch:
         operation: INSERT_BEFORE
         value:
+          name: envoy.filters.http.lua
+          typed_config:
+            "@type": type.googleapis.com/envoy.extensions.filters.http.lua.v3.Lua
+            inline_code: |
+              function envoy_on_request(request_handle)
+                -- Extract the source IP and add it as a header for rate limiting
+                local headers = request_handle:headers()
+                local source_ip = request_handle:streamInfo():downstreamRemoteAddress():ip()
+                headers:add("x-user-ip", source_ip)
+              end
+    # Then, add the local rate limiting filter that uses the injected header
+    - applyTo: HTTP_FILTER
+      match:
+        context: GATEWAY
+        listener:
+          filterChain:
+            filter:
+              name: "envoy.filters.network.http_connection_manager"
+              subFilter:
+                name: "envoy.filters.http.lua"
+      patch:
+        operation: INSERT_AFTER
+        value:
           name: envoy.filters.http.local_ratelimit
           typed_config:
             "@type": type.googleapis.com/udpa.type.v1.TypedStruct
             type_url: type.googleapis.com/envoy.extensions.filters.http.local_ratelimit.v3.LocalRateLimit
             value:
               stat_prefix: http_local_rate_limiter
-              # Per-client rate limiting: {{ .Values.rateLimit.requestsPerMinute }} requests per minute per source IP
+              # Default token bucket configuration (fallback)
               token_bucket:
                 max_tokens: {{ .Values.rateLimit.requestsPerMinute }}
                 tokens_per_fill: {{ .Values.rateLimit.requestsPerMinute }}
@@ -47,14 +71,20 @@ spec:
                 default_value:
                   numerator: 100
                   denominator: HUNDRED
-              # Per-client rate limiting based on source IP
+              # Configure per-user rate limiting using the injected source IP header
+              # This creates separate rate limit counters for each unique source IP
               descriptors:
-              - entries:
-                - key: remote_address
-                rate_limit:
-                  unit: minute
-                  requests_per_unit: {{ .Values.rateLimit.requestsPerMinute }}
-              # Return empty response body when rate limited (only 429 status code)
+                - entries:
+                    - key: "user_ip"
+                      # Use the header we injected with the source IP
+                      request_headers:
+                        header_name: "x-user-ip"
+                        descriptor_key: "user_ip"
+                  token_bucket:
+                    max_tokens: {{ .Values.rateLimit.requestsPerMinute }}
+                    tokens_per_fill: {{ .Values.rateLimit.requestsPerMinute }}
+                    fill_interval: 60s
+              # Return response when rate limited
               local_reply_config:
                 status_code: 429
                 body:

--- a/helm/myapp-chart/values.yaml
+++ b/helm/myapp-chart/values.yaml
@@ -107,7 +107,7 @@ appFrontend:
   replicaCount: 2
   image:
     repository: ghcr.io/remla25-team15/app-frontend
-    tag: "v3.3.0"
+    tag: "v3.1.0"
   hostIP: "0.0.0.0"
   configMapName: "app-frontend-config"
   appServiceHost: "app-service"

--- a/helm/myapp-chart/values.yaml
+++ b/helm/myapp-chart/values.yaml
@@ -177,9 +177,9 @@ env:
   FLASK_ENV: "production"
 
 # Rate limiting configuration
-# This implements local rate limiting using Envoy filters for individual users
+# This implements per-client rate limiting using Envoy filters for individual users
 # Rate limiting is based on source IP address to maintain sticky sessions
 rateLimit:
   enabled: true
-  # Requests per minute allowed per user IP address
-  requestsPerMinute: 200
+  # Requests per minute allowed per individual user (as per assignment requirement)
+  requestsPerMinute: 10

--- a/helm/myapp-chart/values.yaml
+++ b/helm/myapp-chart/values.yaml
@@ -115,7 +115,7 @@ appFrontend:
     v1:
       tag: "v3.3.1"
     v2:
-      tag: "v3.3.2"
+      tag: "v3.3.1-feat-ui-icon"
 
 appService:
   port: 5000

--- a/helm/myapp-chart/values.yaml
+++ b/helm/myapp-chart/values.yaml
@@ -181,9 +181,9 @@ env:
   FLASK_ENV: "production"
 
 # Rate limiting configuration
-# This implements per-client rate limiting using Envoy filters for individual users
-# Rate limiting is based on source IP address to maintain sticky sessions
+# This implements per-user rate limiting using Envoy filters for individual users
+# Rate limiting is based on source IP address with separate buckets per user (similar to sticky sessions)
 rateLimit:
   enabled: true
-  # Requests per minute allowed per individual user (as per assignment requirement)
+  # Requests per minute allowed per individual user (separate bucket per source IP)
   requestsPerMinute: 10

--- a/helm/myapp-chart/values.yaml
+++ b/helm/myapp-chart/values.yaml
@@ -107,11 +107,15 @@ appFrontend:
   replicaCount: 2
   image:
     repository: ghcr.io/remla25-team15/app-frontend
-    tag: "v3.1.0"
   hostIP: "0.0.0.0"
   configMapName: "app-frontend-config"
   appServiceHost: "app-service"
   servicePort: 80
+  versions:
+    v1:
+      tag: "v3.3.1"
+    v2:
+      tag: "v3.3.2"
 
 appService:
   port: 5000


### PR DESCRIPTION
# Implement Per-User Rate Limiting

## Summary
Changed rate limiting from a shared global bucket to per-user buckets based on source IP address, similar to the sticky sessions implementation.

## Changes
- **Modified EnvoyFilter configuration** to create separate rate limit buckets for each unique source IP
- **Added Lua filter** to extract source IP and inject it as a header for rate limiting
- **Updated rate limit descriptors** to use the injected source IP header for per-user tracking
- **Updated documentation** in values.yaml to reflect per-user rate limiting approach

## Details
- Each user (identified by source IP) now gets their own token bucket with 10 requests/minute
- Uses the same source IP extraction approach as sticky sessions for consistency
- Maintains the same rate limit (10 req/min) but now applied per individual user instead of globally
- Prevents one user from consuming the entire rate limit quota and affecting other users

Fixes issue where all users shared a single rate limit bucket, causing unfair throttling across different users.